### PR TITLE
Add basic authentication

### DIFF
--- a/app/components/ui/navbar.tsx
+++ b/app/components/ui/navbar.tsx
@@ -1,6 +1,10 @@
 import { Link, useLocation } from "@remix-run/react";
+import type { User } from "@prisma/client";
 
-export default function Navbar() {
+type NavbarProps = {
+  user: User | null;
+};
+export default function Navbar({ user }: NavbarProps) {
   const location = useLocation();
   const currentPath = location.pathname;
 
@@ -14,7 +18,7 @@ export default function Navbar() {
     <nav className="bg-gray-900 text-white px-6 py-4 shadow">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
         <div className="font-bold text-lg">📚 Remix Library</div>
-        <ul className="flex space-x-6">
+        <ul className="flex space-x-6 items-center">
           {navItems.map((item) => (
             <li key={item.path}>
               <Link
@@ -27,6 +31,21 @@ export default function Navbar() {
               </Link>
             </li>
           ))}
+          {user ? (
+            <li>
+              <form action="/logout" method="post">
+                <button type="submit" className="hover:underline">
+                  Logout
+                </button>
+              </form>
+            </li>
+          ) : (
+            <li>
+              <Link to="/login" className="hover:underline">
+                Login
+              </Link>
+            </li>
+          )}
         </ul>
       </div>
     </nav>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,12 +1,20 @@
-import type { MetaFunction, LinksFunction } from "@remix-run/node";
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+import type { MetaFunction, LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
+import { json } from "@remix-run/node";
+import { getUser } from "~/utils/session.server";
 import styles from "./tailwind.css";
 import Navbar from "~/components/ui/navbar";
 
 export const meta: MetaFunction = () => [{ title: "Remix Library" }];
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
 
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request);
+  return json({ user });
+}
+
 export default function App() {
+  const { user } = useLoaderData<typeof loader>();
   return (
     <html lang="en">
       <head>
@@ -14,7 +22,7 @@ export default function App() {
         <Links />
       </head>
       <body className="bg-gray-100 text-gray-900">
-        <Navbar />
+        <Navbar user={user} />
         <main className="p-6">
           <Outlet />
         </main>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,60 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json } from "@remix-run/node";
+import { Form, Link, useActionData } from "@remix-run/react";
+import { login } from "~/utils/auth.server";
+import { createUserSession, getUser } from "~/utils/session.server";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request);
+  if (user) return json(null, { status: 302, headers: { Location: "/" } });
+  return json(null);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const email = form.get("email");
+  const password = form.get("password");
+  if (typeof email !== "string" || typeof password !== "string") {
+    return json({ error: "Invalid Form" }, { status: 400 });
+  }
+  const user = await login(email, password);
+  if (!user) {
+    return json({ error: "Invalid credentials" }, { status: 400 });
+  }
+  return createUserSession(user.id, "/");
+}
+
+export default function Login() {
+  const actionData = useActionData<typeof action>();
+  return (
+    <Card className="mx-auto mt-10 max-w-sm">
+      <CardHeader>
+        <CardTitle>Login</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form method="post" className="space-y-4">
+          {actionData?.error && (
+            <p className="text-sm text-red-600">{actionData.error}</p>
+          )}
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" required />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input id="password" name="password" type="password" required />
+          </div>
+          <Button type="submit" className="w-full">
+            Log in
+          </Button>
+        </Form>
+        <p className="mt-4 text-center text-sm">
+          No account? <Link to="/register" className="underline">Sign up</Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,0 +1,15 @@
+import { ActionFunctionArgs } from "@remix-run/node";
+import { Form } from "@remix-run/react";
+import { logout } from "~/utils/session.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  return logout(request);
+}
+
+export default function Logout() {
+  return (
+    <Form method="post">
+      <button type="submit" className="hidden" />
+    </Form>
+  );
+}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,0 +1,62 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json } from "@remix-run/node";
+import { Form, Link, useActionData } from "@remix-run/react";
+import { register } from "~/utils/auth.server";
+import { createUserSession, getUser } from "~/utils/session.server";
+import { prisma } from "~/lib/prisma.server";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request);
+  if (user) return json(null, { status: 302, headers: { Location: "/" } });
+  return json(null);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const email = form.get("email");
+  const password = form.get("password");
+  if (typeof email !== "string" || typeof password !== "string") {
+    return json({ error: "Invalid Form" }, { status: 400 });
+  }
+  const existingUser = await prisma.user.findUnique({ where: { email } });
+  if (existingUser) {
+    return json({ error: "User already exists" }, { status: 400 });
+  }
+  const user = await register(email, password);
+  return createUserSession(user.id, "/");
+}
+
+export default function Register() {
+  const actionData = useActionData<typeof action>();
+  return (
+    <Card className="mx-auto mt-10 max-w-sm">
+      <CardHeader>
+        <CardTitle>Register</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form method="post" className="space-y-4">
+          {actionData?.error && (
+            <p className="text-sm text-red-600">{actionData.error}</p>
+          )}
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" required />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input id="password" name="password" type="password" required />
+          </div>
+          <Button type="submit" className="w-full">
+            Sign up
+          </Button>
+        </Form>
+        <p className="mt-4 text-center text-sm">
+          Already have an account? <Link to="/login" className="underline">Log in</Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -1,0 +1,15 @@
+import bcrypt from "bcryptjs";
+import { prisma } from "~/lib/prisma.server";
+
+export async function register(email: string, password: string) {
+  const hashed = await bcrypt.hash(password, 10);
+  return prisma.user.create({ data: { email, password: hashed } });
+}
+
+export async function login(email: string, password: string) {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return null;
+  const isValid = await bcrypt.compare(password, user.password);
+  if (!isValid) return null;
+  return user;
+}

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -1,0 +1,66 @@
+import { createCookieSessionStorage, redirect } from "@remix-run/node";
+import { prisma } from "~/lib/prisma.server";
+
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  throw new Error("SESSION_SECRET must be set");
+}
+
+export const storage = createCookieSessionStorage({
+  cookie: {
+    name: "_session",
+    secure: process.env.NODE_ENV === "production",
+    secrets: [sessionSecret],
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+    httpOnly: true,
+  },
+});
+
+export async function createUserSession(userId: number, redirectTo: string) {
+  const session = await storage.getSession();
+  session.set("userId", userId);
+  return redirect(redirectTo, {
+    headers: {
+      "Set-Cookie": await storage.commitSession(session),
+    },
+  });
+}
+
+export async function getUserId(request: Request) {
+  const session = await storage.getSession(request.headers.get("Cookie"));
+  const userId = session.get("userId");
+  if (typeof userId !== "number") return null;
+  return userId;
+}
+
+export async function getUser(request: Request) {
+  const userId = await getUserId(request);
+  if (userId === null) return null;
+  try {
+    return await prisma.user.findUnique({ where: { id: userId } });
+  } catch {
+    return null;
+  }
+}
+
+export async function requireUserId(request: Request) {
+  const userId = await getUserId(request);
+  if (!userId) {
+    const params = new URLSearchParams([
+      ["redirectTo", new URL(request.url).pathname],
+    ]);
+    throw redirect(`/login?${params}`);
+  }
+  return userId;
+}
+
+export async function logout(request: Request) {
+  const session = await storage.getSession(request.headers.get("Cookie"));
+  return redirect("/login", {
+    headers: {
+      "Set-Cookie": await storage.destroySession(session),
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@remix-run/node": "^2.16.7",
         "@remix-run/react": "^2.16.7",
         "@remix-run/serve": "^2.16.7",
+        "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "init": "^0.1.2",
@@ -2448,6 +2449,12 @@
     },
     "node_modules/basic-auth/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@remix-run/node": "^2.16.7",
     "@remix-run/react": "^2.16.7",
     "@remix-run/serve": "^2.16.7",
+    "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "init": "^0.1.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,3 +21,10 @@ model Book {
   authorId Int
   author   Author @relation(fields: [authorId], references: [id])
 }
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add User model
- create session management and auth helpers
- implement login, register and logout routes
- update navbar to show login/logout
- load user in root and pass down to Navbar
- install bcryptjs

## Testing
- `npm run lint` *(fails: Failed to load plugin 'react')*
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684061a85f9c8332ab29b439c8981807