### PR TITLE
Fix lint issues and add types

### DIFF
--- a/app/db/prisma.ts
+++ b/app/db/prisma.ts
@@ -1,16 +1,11 @@
 import { PrismaClient } from '@prisma/client';
 export const prisma = new PrismaClient();
 
+const globalWithDb = global as typeof global & {
+  __db__?: PrismaClient;
+};
 
-let db: PrismaClient;
-
-declare global {
-  var __db__: PrismaClient | undefined;
-}
-
-if (!global.__db__) {
-  global.__db__ = new PrismaClient();
-}
-db = global.__db__;
+const db: PrismaClient =
+  globalWithDb.__db__ ?? (globalWithDb.__db__ = new PrismaClient());
 
 export { db };

--- a/app/lib/prisma.server.ts
+++ b/app/lib/prisma.server.ts
@@ -2,18 +2,17 @@ import { PrismaClient } from "@prisma/client";
 
 let prisma: PrismaClient;
 
-declare global {
-  // Prevent multiple instances in development
-  var __db: PrismaClient | undefined;
-}
+const globalWithPrisma = global as typeof global & {
+  __db?: PrismaClient;
+};
 
 if (process.env.NODE_ENV === "production") {
   prisma = new PrismaClient();
 } else {
-  if (!global.__db) {
-    global.__db = new PrismaClient();
+  if (!globalWithPrisma.__db) {
+    globalWithPrisma.__db = new PrismaClient();
   }
-  prisma = global.__db;
+  prisma = globalWithPrisma.__db;
 }
 
 export { prisma };

--- a/app/lib/prisma.ts
+++ b/app/lib/prisma.ts
@@ -2,15 +2,15 @@ import { PrismaClient } from "@prisma/client";
 
 let prisma: PrismaClient;
 
-declare global {
-  var __db: PrismaClient | undefined;
-}
+const globalWithPrisma = global as typeof global & {
+  __db?: PrismaClient;
+};
 
 if (process.env.NODE_ENV === "production") {
   prisma = new PrismaClient();
 } else {
-  if (!global.__db) global.__db = new PrismaClient();
-  prisma = global.__db;
+  if (!globalWithPrisma.__db) globalWithPrisma.__db = new PrismaClient();
+  prisma = globalWithPrisma.__db;
 }
 
 export { prisma };

--- a/app/routes/authors.$authorId.tsx
+++ b/app/routes/authors.$authorId.tsx
@@ -1,9 +1,14 @@
 // app/routes/authors.$authorId.tsx
-import { json } from "@remix-run/node";
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+type Book = {
+  id: number;
+  title: string;
+  year: number;
+};
 import { useLoaderData } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 
-export async function loader({ params }: any) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const author = await prisma.author.findUnique({
     where: { id: Number(params.authorId) },
     include: { books: true },
@@ -25,7 +30,7 @@ export default function AuthorDetailPage() {
       <h2 className="text-lg font-semibold">Books:</h2>
       <ul className="space-y-2">
         {author.books.length === 0 && <p>No books found for this author.</p>}
-        {author.books.map((book) => (
+        {author.books.map((book: Book) => (
           <li key={book.id} className="border p-3 rounded">
             {book.title} ({book.year})
           </li>

--- a/app/routes/authors.index.tsx
+++ b/app/routes/authors.index.tsx
@@ -3,6 +3,10 @@ import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 import { Button } from "~/components/ui/button";
+type Author = {
+  id: number;
+  name: string;
+};
 
 export async function loader() {
   const authors = await prisma.author.findMany({
@@ -24,7 +28,7 @@ export default function AuthorsPage() {
       </div>
 
       <ul className="space-y-3">
-        {authors.map((author) => (
+        {authors.map((author: Author) => (
           <li key={author.id} className="border p-4 rounded">
             <Link to={`/authors/${author.id}`} className="font-semibold hover:underline">
               {author.name}

--- a/app/routes/authors.new.tsx
+++ b/app/routes/authors.new.tsx
@@ -1,11 +1,11 @@
 // app/routes/authors.new.tsx
-import { json, redirect } from "@remix-run/node";
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
 import { Form } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 
-export async function action({ request }: any) {
+export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const name = formData.get("name");
 

--- a/app/routes/books.$bookId_.edit.tsx
+++ b/app/routes/books.$bookId_.edit.tsx
@@ -1,6 +1,10 @@
 // app/routes/books.$bookId.edit.tsx
 import { json, redirect } from "@remix-run/node";
 import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+type Author = {
+  id: number;
+  name: string;
+};
 import { useLoaderData, Form } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 import { Input } from "~/components/ui/input";
@@ -65,7 +69,7 @@ export default function EditBookPage() {
                 required
               >
                 <option value="">Select Author</option>
-                {authors.map((author) => (
+                {authors.map((author: Author) => (
                   <option key={author.id} value={author.id}>
                     {author.name}
                   </option>

--- a/app/routes/books.index.tsx
+++ b/app/routes/books.index.tsx
@@ -1,12 +1,17 @@
 // app/routes/books.index.tsx
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
-import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { prisma } from "~/lib/prisma.server";
+type Book = {
+  id: number;
+  title: string;
+  year: number;
+  author?: { name?: string | null } | null;
+};
 
-export async function loader({}: LoaderFunctionArgs) {
+export async function loader() {
   const books = await prisma.book.findMany({
     orderBy: { id: "asc" },
     include: { author: true }, // ✅ Author maʼlumotini olib kelamiz
@@ -29,7 +34,7 @@ export default function BooksPage() {
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-        {books.map((book) => (
+        {books.map((book: Book) => (
           <Card key={book.id}>
             <CardHeader>
               <CardTitle className="text-xl font-semibold">{book.title}</CardTitle>

--- a/app/routes/books.new.tsx
+++ b/app/routes/books.new.tsx
@@ -1,13 +1,17 @@
 import { json, redirect } from "@remix-run/node";
-import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/node";
 import { useLoaderData, Form } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+type Author = {
+  id: number;
+  name: string;
+};
 
-export async function loader({}: LoaderFunctionArgs) {
+export async function loader() {
   const authors = await prisma.author.findMany({
     orderBy: { name: "asc" },
   });
@@ -61,7 +65,7 @@ export default function NewBookPage() {
               <Label htmlFor="authorId">Muallif</Label>
               <select name="authorId" id="authorId" className="w-full border rounded p-2" required>
                 <option value="">Muallifni tanlang</option>
-                {authors.map((author) => (
+                {authors.map((author: Author) => (
                   <option key={author.id} value={author.id}>
                     {author.name}
                   </option>

--- a/app/types/global.d.ts
+++ b/app/types/global.d.ts
@@ -1,0 +1,8 @@
+import type { PrismaClient } from "@prisma/client";
+
+declare global {
+  let __db__: PrismaClient | undefined;
+  let __db: PrismaClient | undefined;
+}
+
+export {};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,70 +1,70 @@
 import type { Config } from "tailwindcss";
 
 export default {
-    darkMode: ["class"],
-    content: ["./app/**/{**,.client,.server}/**/*.{js,jsx,ts,tsx}"],
+  darkMode: ["class"],
+  content: ["./app/**/{**,.client,.server}/**/*.{js,jsx,ts,tsx}"],
   theme: {
-  	extend: {
-  		fontFamily: {
-  			sans: [
-  				'Inter',
-  				'ui-sans-serif',
-  				'system-ui',
-  				'sans-serif',
-  				'Apple Color Emoji',
-  				'Segoe UI Emoji',
-  				'Segoe UI Symbol',
-  				'Noto Color Emoji'
-  			]
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		}
-  	}
+    extend: {
+      fontFamily: {
+        sans: [
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "sans-serif",
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Segoe UI Symbol",
+          "Noto Color Emoji",
+        ],
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+      },
+    },
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace `var` usage in Prisma helpers with `let` and add a single global typing file
- add explicit loader/action typings in routes
- give map callbacks proper types
- normalize indentation in `tailwind.config.ts`

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684063931b5c83329b406420e95104e4