### PR TITLE
Add cart and order functionality

### DIFF
--- a/app/components/ui/navbar.tsx
+++ b/app/components/ui/navbar.tsx
@@ -11,6 +11,8 @@ export default function Navbar({ user }: NavbarProps) {
   const navItems = [
     { path: "/books", label: "Books" },
     { path: "/authors", label: "Authors" },
+    { path: "/cart", label: "Cart" },
+    { path: "/orders", label: "Orders" },
     { path: "/", label: "Home" },
   ];
 

--- a/app/routes/books.$bookId.tsx
+++ b/app/routes/books.$bookId.tsx
@@ -1,9 +1,10 @@
 // app/routes/books.$bookId.tsx
 import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { useLoaderData, useFetcher } from "@remix-run/react";
 import { prisma } from "~/lib/prisma.server";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { Card, CardHeader, CardTitle, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const id = Number(params.bookId);
@@ -20,6 +21,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
 export default function BookDetailPage() {
   const book = useLoaderData<typeof loader>();
+  const fetcher = useFetcher();
 
   return (
     <div className="max-w-xl mx-auto p-6">
@@ -30,6 +32,11 @@ export default function BookDetailPage() {
         <CardContent className="space-y-2">
           <p><strong>Muallif:</strong> {book.author}</p>
           <p><strong>Yil:</strong> {book.year}</p>
+          <p><strong>Narx:</strong> ${'{'}book.price{'}'}</p>
+          <fetcher.Form method="post" action="/cart/add">
+            <input type="hidden" name="bookId" value={book.id} />
+            <Button variant="outline" size="sm">Add to Cart</Button>
+          </fetcher.Form>
         </CardContent>
       </Card>
     </div>

--- a/app/routes/books.$bookId_.edit.tsx
+++ b/app/routes/books.$bookId_.edit.tsx
@@ -34,6 +34,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     data: {
       title: String(form.get("title")),
       year: Number(form.get("year")),
+      price: Number(form.get("price")),
       authorId: Number(form.get("authorId")), // e'tibor bering
     },
   });
@@ -80,6 +81,11 @@ export default function EditBookPage() {
             <div>
               <Label htmlFor="year">Year</Label>
               <Input name="year" id="year" defaultValue={book.year} type="number" required />
+            </div>
+
+            <div>
+              <Label htmlFor="price">Price</Label>
+              <Input name="price" id="price" defaultValue={book.price} type="number" step="0.01" required />
             </div>
 
             <div className="flex justify-end">

--- a/app/routes/books.index.tsx
+++ b/app/routes/books.index.tsx
@@ -8,6 +8,7 @@ type Book = {
   id: number;
   title: string;
   year: number;
+  price: number;
   author?: { name?: string | null } | null;
 };
 
@@ -36,16 +37,21 @@ export default function BooksPage() {
       <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         {books.map((book: Book) => (
           <Card key={book.id}>
-            <CardHeader>
-              <CardTitle className="text-xl font-semibold">{book.title}</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                {book.author?.name || "Unknown Author"} ({book.year})
-              </p>
-            </CardHeader>
-            <CardContent className="flex justify-end gap-2">
-              <Link to={`/books/${book.id}/edit`}>
-                <Button variant="outline" size="sm">Edit</Button>
-              </Link>
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold">{book.title}</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {book.author?.name || "Unknown Author"} ({book.year})
+            </p>
+            <p className="text-sm">${'{'}book.price{'}'}</p>
+          </CardHeader>
+          <CardContent className="flex justify-end gap-2">
+            <fetcher.Form method="post" action="/cart/add">
+              <input type="hidden" name="bookId" value={book.id} />
+              <Button variant="outline" size="sm">Add to Cart</Button>
+            </fetcher.Form>
+            <Link to={`/books/${book.id}/edit`}>
+              <Button variant="outline" size="sm">Edit</Button>
+            </Link>
               <fetcher.Form method="post" action={`/books/${book.id}/delete`}>
                 <input type="hidden" name="_method" value="delete" />
                 <Button variant="destructive" size="sm">Delete</Button>

--- a/app/routes/books.new.tsx
+++ b/app/routes/books.new.tsx
@@ -23,9 +23,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const title = String(form.get("title"));
   const year = Number(form.get("year"));
+  const price = Number(form.get("price"));
   const authorId = Number(form.get("authorId"));
 
-  if (!title || !year || !authorId) {
+  if (!title || !year || !authorId || isNaN(price)) {
     throw new Response("Invalid form submission", { status: 400 });
   }
 
@@ -33,6 +34,7 @@ export async function action({ request }: ActionFunctionArgs) {
     data: {
       title,
       year,
+      price,
       author: { connect: { id: authorId } },
     },
   });
@@ -59,6 +61,11 @@ export default function NewBookPage() {
             <div>
               <Label htmlFor="year">Yil</Label>
               <Input type="number" id="year" name="year" required />
+            </div>
+
+            <div>
+              <Label htmlFor="price">Narx</Label>
+              <Input type="number" step="0.01" id="price" name="price" required />
             </div>
 
             <div>

--- a/app/routes/cart.add.tsx
+++ b/app/routes/cart.add.tsx
@@ -1,0 +1,23 @@
+import { redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { addToCart, commitCartSession, getCartSession } from "~/utils/cart.server";
+import { prisma } from "~/lib/prisma.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const bookId = Number(form.get("bookId"));
+  const quantity = Number(form.get("quantity")) || 1;
+  if (!bookId) {
+    throw new Response("Invalid book", { status: 400 });
+  }
+  const book = await prisma.book.findUnique({ where: { id: bookId } });
+  if (!book) {
+    throw new Response("Book not found", { status: 404 });
+  }
+  const session = await getCartSession(request);
+  addToCart(session, { bookId, quantity, price: book.price });
+  return redirect("/cart", {
+    headers: {
+      "Set-Cookie": await commitCartSession(session),
+    },
+  });
+}

--- a/app/routes/cart.remove.tsx
+++ b/app/routes/cart.remove.tsx
@@ -1,0 +1,15 @@
+import { redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { commitCartSession, getCartSession, removeFromCart } from "~/utils/cart.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const bookId = Number(form.get("bookId"));
+  if (!bookId) throw new Response("Invalid book", { status: 400 });
+  const session = await getCartSession(request);
+  removeFromCart(session, bookId);
+  return redirect("/cart", {
+    headers: {
+      "Set-Cookie": await commitCartSession(session),
+    },
+  });
+}

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -1,0 +1,75 @@
+import { json, redirect } from "@remix-run/node";
+import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+import { prisma } from "~/lib/prisma.server";
+import { requireUserId } from "~/utils/session.server";
+import { clearCart, getCart, getCartSession, commitCartSession } from "~/utils/cart.server";
+import { Button } from "~/components/ui/button";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getCartSession(request);
+  const cart = getCart(session);
+  const bookIds = cart.map((c) => c.bookId);
+  const books = await prisma.book.findMany({ where: { id: { in: bookIds } } });
+  const items = cart.map((c) => {
+    const book = books.find((b) => b.id === c.bookId)!;
+    return { ...c, title: book.title };
+  });
+  const total = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+  return json({ items, total });
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  const session = await getCartSession(request);
+  const cart = getCart(session);
+  if (cart.length === 0) return redirect("/cart");
+
+  // create order
+  await prisma.order.create({
+    data: {
+      userId,
+      items: {
+        create: cart.map((c) => ({ bookId: c.bookId, quantity: c.quantity, price: c.price })),
+      },
+    },
+  });
+  clearCart(session);
+  return redirect(`/orders`, {
+    headers: {
+      "Set-Cookie": await commitCartSession(session),
+    },
+  });
+}
+
+export default function CartPage() {
+  const { items, total } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Shopping Cart</h1>
+      {items.length === 0 ? (
+        <p>Your cart is empty.</p>
+      ) : (
+        <div className="space-y-4">
+          <ul className="space-y-2">
+            {items.map((item) => (
+              <li key={item.bookId} className="flex justify-between items-center border p-2 rounded">
+                <div>
+                  {item.title} (x{item.quantity}) - ${'{'}item.price{'}'}
+                </div>
+                <Form method="post" action="/cart/remove">
+                  <input type="hidden" name="bookId" value={item.bookId} />
+                  <Button variant="destructive" size="sm">Remove</Button>
+                </Form>
+              </li>
+            ))}
+          </ul>
+          <p className="font-semibold">Total: ${'{'}total.toFixed(2){'}'}</p>
+          <Form method="post">
+            <Button type="submit">Checkout</Button>
+          </Form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/routes/orders.index.tsx
+++ b/app/routes/orders.index.tsx
@@ -1,0 +1,42 @@
+import { json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { prisma } from "~/lib/prisma.server";
+import { requireUserId } from "~/utils/session.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await requireUserId(request);
+  const orders = await prisma.order.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    include: { items: { include: { book: true } } },
+  });
+  return json({ orders });
+}
+
+export default function OrdersPage() {
+  const { orders } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-2xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Your Orders</h1>
+      {orders.length === 0 ? (
+        <p>No orders yet.</p>
+      ) : (
+        <ul className="space-y-4">
+          {orders.map((order) => (
+            <li key={order.id} className="border p-4 rounded">
+              <p className="font-semibold">Order #{order.id}</p>
+              <ul className="ml-4 list-disc">
+                {order.items.map((item) => (
+                  <li key={item.id}>
+                    {item.book.title} x{item.quantity} (${item.price})
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/utils/cart.server.ts
+++ b/app/utils/cart.server.ts
@@ -1,0 +1,37 @@
+import { storage } from "./session.server";
+
+export type CartItem = { bookId: number; quantity: number; price: number };
+
+export async function getCartSession(request: Request) {
+  return storage.getSession(request.headers.get("Cookie"));
+}
+
+export function getCart(session: Awaited<ReturnType<typeof getCartSession>>): CartItem[] {
+  const cart = session.get("cart");
+  if (Array.isArray(cart)) return cart as CartItem[];
+  return [];
+}
+
+export function addToCart(session: Awaited<ReturnType<typeof getCartSession>>, item: CartItem) {
+  const cart = getCart(session);
+  const existing = cart.find((c) => c.bookId === item.bookId);
+  if (existing) {
+    existing.quantity += item.quantity;
+  } else {
+    cart.push(item);
+  }
+  session.set("cart", cart);
+}
+
+export function removeFromCart(session: Awaited<ReturnType<typeof getCartSession>>, bookId: number) {
+  const cart = getCart(session).filter((i) => i.bookId !== bookId);
+  session.set("cart", cart);
+}
+
+export function clearCart(session: Awaited<ReturnType<typeof getCartSession>>) {
+  session.set("cart", []);
+}
+
+export function commitCartSession(session: Awaited<ReturnType<typeof getCartSession>>) {
+  return storage.commitSession(session);
+}

--- a/prisma/migrations/20250529133500_add_cart_orders/migration.sql
+++ b/prisma/migrations/20250529133500_add_cart_orders/migration.sql
@@ -1,0 +1,25 @@
+-- Add price column to Book
+ALTER TABLE "Book" ADD COLUMN "price" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- Create Order table
+CREATE TABLE "Order" (
+  "id" SERIAL NOT NULL,
+  "userId" INTEGER NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+-- Create OrderItem table
+CREATE TABLE "OrderItem" (
+  "id" SERIAL NOT NULL,
+  "orderId" INTEGER NOT NULL,
+  "bookId" INTEGER NOT NULL,
+  "quantity" INTEGER NOT NULL DEFAULT 1,
+  "price" DOUBLE PRECISION NOT NULL,
+  CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- Add Foreign Keys
+ALTER TABLE "Order" ADD CONSTRAINT "Order_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,27 @@ model Book {
   id       Int    @id @default(autoincrement())
   title    String
   year     Int
+  price    Float
   authorId Int
   author   Author @relation(fields: [authorId], references: [id])
+}
+
+model Order {
+  id        Int       @id @default(autoincrement())
+  userId    Int
+  user      User      @relation(fields: [userId], references: [id])
+  createdAt DateTime  @default(now())
+  items     OrderItem[]
+}
+
+model OrderItem {
+  id       Int   @id @default(autoincrement())
+  orderId  Int
+  bookId   Int
+  quantity Int   @default(1)
+  price    Float
+  order    Order @relation(fields: [orderId], references: [id])
+  book     Book  @relation(fields: [bookId], references: [id])
 }
 
 model User {

--- a/tests/routes.server.test.tsx
+++ b/tests/routes.server.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 vi.mock('~/lib/prisma.server', () => {
   const data = {
     authors: [{ id: 1, name: 'A' }],
-    books: [{ id: 1, title: 'T', year: 2020, authorId: 1, author: { id:1, name:'A'} }]
+    books: [{ id: 1, title: 'T', year: 2020, price: 10, authorId: 1, author: { id:1, name:'A'} }]
   };
   return {
     prisma: {
@@ -91,7 +91,7 @@ describe('books loader', () => {
 describe('books page', () => {
   it('renders list', async () => {
     const react = require('@remix-run/react');
-    vi.spyOn(react, 'useLoaderData').mockReturnValue({ books: [{ id: 1, title: 'R', year: 2021, author: { name: 'A' } }] } as any);
+    vi.spyOn(react, 'useLoaderData').mockReturnValue({ books: [{ id: 1, title: 'R', year: 2021, price: 5, author: { name: 'A' } }] } as any);
     const mod = await import('~/routes/books.index');
     const Page = mod.default;
     const router = require('react-router-dom').createMemoryRouter([
@@ -110,7 +110,7 @@ describe('create book action', () => {
     const action = mod.action;
     const req = new Request('http://test', {
       method: 'POST',
-      body: new URLSearchParams({ title: 'Book', year: '2024', authorId: '1' }).toString(),
+      body: new URLSearchParams({ title: 'Book', year: '2024', price: '9.99', authorId: '1' }).toString(),
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
     });
     await action({ request: req } as any);


### PR DESCRIPTION
## Summary
- add `price` and order tables to Prisma schema
- include new migration for the cart/order schema changes
- implement cart utilities and routes
- add order listing route
- update book create/edit forms and listings with price
- update navbar links and tests for new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684071898ec483328d7295d051d00110